### PR TITLE
Cache activator info

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -13,6 +13,7 @@ import time
 import urllib.parse
 import re
 from threading import Lock
+from cachetools.func import ttl_cache
 
 mutex_lock = Lock()
 
@@ -192,6 +193,7 @@ def query_rbn(call: str):
     return None
 
 
+@ttl_cache(ttl=6*60*60)  # 6hours
 def get_activator_stats(activator: str):
     '''Return all spot + comments from a given activation'''
     s = get_basecall(activator)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aiohttp==3.9.5
 aiosignal==1.3.1
 async-timeout==4.0.3
 attrs==23.2.0
+cachetools==5.4.0
 certifi==2024.2.2
 charset-normalizer==3.3.2
 discord.py==2.3.2


### PR DESCRIPTION
This data is unlikely to change between spot updates, so utilise a cache, currently set to 6hours.