### PR TITLE
Migrate from requests to aiohttp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,9 @@
 aiohttp==3.9.5
 aiosignal==1.3.1
-async-timeout==4.0.3
+async-cache==1.1.1
 attrs==23.2.0
-cachetools==5.4.0
-certifi==2024.2.2
-charset-normalizer==3.3.2
 discord.py==2.3.2
 frozenlist==1.4.1
 idna==3.7
 multidict==6.0.5
-requests==2.31.0
-urllib3==2.2.1
 yarl==1.9.4


### PR DESCRIPTION
I've noticed some warnings about blocking too long for bot heartbeat and see discord.py recommends not using `requests` due to it blocking, and instead to use `aiohttp`.

This change moves all `requests` usage to `aiohttp` as well as changing the caching library for pota profiles to asynchronous compatible alternative.