### PR TITLE
Fixes for RBN api update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ pertinent data. And place your schedule.json and callsigns.txt files in the same
 version: "3"
 services:
   myradicalbot:
-    image: krinkl3/spotbot:1.1-amd64
+    image: krinkl3/spotbot:1.12-amd64
     volumes:
       - type: bind
         source: ./callsigns.txt
@@ -71,6 +71,7 @@ services:
       CALLSIGN_MGR_ROLE_ID: "role id here"  # id of role to add/remove callsigns
       PING_ROLE_ID: "role id here"  # id of role to ping in spot embeds
       DISABLE_RBN: '0'
+      RBN_HDR: "6fa56c"
     restart: unless-stopped
 ```
 
@@ -91,6 +92,10 @@ set them in your `docker-compose.yml`):
 * `CALLSIGN_MGR_ROLE_ID` - The role ID for users to add/remove spots to tracking list
 * `PING_ROLE_ID` - The role ID that will be pinged in spots
 * `DISABLE_RBN`: '0' either a '1' or '0'. 1 will turn off querying of RBN spots.
+* `RBN_HDR`: The latest, expected RBN header version as a string ex: '6fa56c' *
+
+\* As of March-2026, this version is **6fa56c**. When the RBN versions changes in the future and 
+if that new version is compatible, you can update this env var and restart container to get RBN spots working.
 
 > The id's should be integer values and are obtained through your discord client
 > except for BOT_TOKEN which is generated via Discord's bot creation webpage. They 

--- a/bot.py
+++ b/bot.py
@@ -7,6 +7,7 @@ import logging
 import logging.handlers
 import os
 import re
+import sys
 import urllib.parse
 from datetime import datetime, timezone, timedelta
 
@@ -30,13 +31,17 @@ callsign_role_id = int(os.environ['CALLSIGN_MGR_ROLE_ID'])
 ping_role = int(os.environ['PING_ROLE_ID'])
 # default disable_rbn to FALSE
 disable_rbn = int(os.environ.get('DISABLE_RBN', '0'))
+rbn_api_hdr = os.environ['RBN_HDR']
 
-handler = logging.handlers.RotatingFileHandler(
-    filename='discord.log',
-    encoding='utf-8',
-    maxBytes=32 * 1024 * 1024,  # 32 MiB
-    backupCount=5,  # Rotate through 5 files
-)
+#handler = logging.handlers.RotatingFileHandler(
+#    filename='discord.log',
+#    encoding='utf-8',
+#    maxBytes=32 * 1024 * 1024,  # 32 MiB
+#    backupCount=5,  # Rotate through 5 files
+#)
+
+# use std out for docker logs
+handler = logging.StreamHandler(sys.stdout)
 
 log = logging.getLogger("discord")
 
@@ -151,7 +156,7 @@ async def get_rbn_spots(session, calls: list[str], last_id: int):
 
 def convert_rbn_to_pota_spot(j, spot):
     arr = j['spots'][spot]
-    t = datetime.fromtimestamp(arr[11], tz=timezone.utc)
+    t = datetime.fromtimestamp(arr[10], tz=timezone.utc)
     timestamp = t.isoformat()
     snr = arr[3]
     wpm = arr[4]
@@ -176,7 +181,10 @@ async def query_rbn(session, calls: list[str], last_id: int):
     # s = last_id
     # r = max rows (100 is highest)
     # cdx = callsign to look for
-    expected_ver = '2aa296'
+
+    # get expected hdr from ENV var
+    expected_ver = rbn_api_hdr  # '2aa296'
+
     calls = [urllib.parse.quote(call) for call in calls]
     url = f'https://www.reversebeacon.net/spots.php?h={expected_ver}&ma=60&m=1&bc=1&s={last_id}&r=100&cdx={",".join(calls)}'
 


### PR DESCRIPTION
## RBN API was updated. 

The RBN API change: timestamp moved to another element in array. Must update for continued RBN support.

Moving forward, use RBN_HDR environment variable to input the most recent expected RBN header. As of 17-Mar-2026 that string should be **6fa56c**

In future, when RBN updates this again it can be updated and possibly avoid having to rebuild the entire container / codebase. Of course, this assumes there are no breaking changes within the RBN API.

Update docker-compose.yml by adding the new environment variable, like so:

```yml
environment:
  RBN_HDR: "6fa56c"
```

## Other changes
Also in here are some logging changes. Bot no longer logs to the file discord.log but instead to stdout. This is so that docker can handle the logs. (And it can route the logs to cloud platforms like Google cloud logs).